### PR TITLE
Fix unnecessary app reinitialization in main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { createMultiStepPlugin } from '@formkit/addons'
 import '@formkit/themes/genesis'
 import '@formkit/addons/css/multistep'
 
-let app = createApp(App)
+const app = createApp(App)
 .use(router)
 .use(formKitPlugin, defaultConfig({
   plugins: [createMultiStepPlugin(),
@@ -18,8 +18,10 @@ let app = createApp(App)
 }))
 .mount('#app')
 
-onAuthStateChanged(auth, () => {
-  if (!app) {
-    app = createApp(App).use(router).mount('#app');
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    console.log("User authenticated:", user);
+  } else {
+    console.log("User not authenticated");
   }
 });


### PR DESCRIPTION
Removed the unnecessary re-initialization logic inside the `onAuthStateChanged` callback. Ensured that the app instance is only created once, avoiding the need to remount the entire app when the authentication state changes.
This fix ensures that the app remains mounted and functional, even if the authentication state changes.