### PR TITLE
Prevent unnecessary app re-initialization and resolve login issue on 'Add Event' page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,5 +36,6 @@ onAuthStateChanged(auth, (user) => {
         ]
       }))
       .mount('#app');
-  }
+    }
 });
+

--- a/src/main.js
+++ b/src/main.js
@@ -9,19 +9,32 @@ import { createMultiStepPlugin } from '@formkit/addons'
 import '@formkit/themes/genesis'
 import '@formkit/addons/css/multistep'
 
-const app = createApp(App)
-.use(router)
-.use(formKitPlugin, defaultConfig({
-  plugins: [createMultiStepPlugin(),
-    createAutoHeightTextareaPlugin()
-   ]
-}))
-.mount('#app')
+let app;
 
 onAuthStateChanged(auth, (user) => {
   if (user) {
     console.log("User authenticated:", user);
+
+    app = createApp(App)
+      .use(router)
+      .use(formKitPlugin, defaultConfig({
+        plugins: [
+          createMultiStepPlugin(),
+          createAutoHeightTextareaPlugin()
+        ]
+      }))
+      .mount('#app');
   } else {
     console.log("User not authenticated");
+
+    app = createApp(App)
+      .use(router)
+      .use(formKitPlugin, defaultConfig({
+        plugins: [
+          createMultiStepPlugin(),
+          createAutoHeightTextareaPlugin()
+        ]
+      }))
+      .mount('#app');
   }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { createMultiStepPlugin } from '@formkit/addons'
 import '@formkit/themes/genesis'
 import '@formkit/addons/css/multistep'
 
-let app = createApp(App)
+const app = createApp(App)
 .use(router)
 .use(formKitPlugin, defaultConfig({
   plugins: [createMultiStepPlugin(),
@@ -18,8 +18,10 @@ let app = createApp(App)
 }))
 .mount('#app')
 
-onAuthStateChanged(auth, () => {
-  if (!app) {
-    app = createApp(App).use(router).mount('#app');
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    console.log("User authenticated:", user);
+  } else {
+    console.log("User not authenticated");
   }
 });


### PR DESCRIPTION
The app was being re-initialized and remounted each time the authentication state changed due to the onAuthStateChanged logic. This caused the application to lose context of the user’s authentication, leading to a login issue specifically on the "Add Event" page.